### PR TITLE
Kill article proxy

### DIFF
--- a/app/src/StoryView.tsx
+++ b/app/src/StoryView.tsx
@@ -6,7 +6,6 @@ type StoryViewProps = {
 };
 
 const StoryView: React.SFC<StoryViewProps> = (props) => {
-  const url = `http://localhost:8900/article-proxy?q=${encodeURIComponent(props.story.url)}`;
   return (
     <iframe
       frameBorder="0"
@@ -14,7 +13,7 @@ const StoryView: React.SFC<StoryViewProps> = (props) => {
         height: '100vh',
         width: '100%',
       }}
-      src={url}
+      src={props.story.url}
     />
   );
 };

--- a/server/main.go
+++ b/server/main.go
@@ -30,8 +30,6 @@ func main() {
 		middleware.NewGrpcWebMiddleware(wrappedGrpc).Handler,
 	)
 
-	router.Get("/article-proxy", proxy.Article)
-
 	if err := http.ListenAndServe(":8900", router); err != nil {
 		grpclog.Fatalf("failed starting http2 server: %v", err)
 	}


### PR DESCRIPTION
Some websites will disallow embedding, which the proxy was solving. But given this is only an example app, the value of this is minimal.